### PR TITLE
Fixed nullptr L""

### DIFF
--- a/oxygen pdb/src/Pdber.cpp
+++ b/oxygen pdb/src/Pdber.cpp
@@ -26,7 +26,14 @@ namespace oxygenPdb {
 
 
 			//then download pdb or open pdb(pdb has exits
-			const auto& cpath = _pdbViewer.downLoadPdb(info).data();
+			const auto& pdb = _pdbViewer.downLoadPdb(info);
+			// Check pdb is empty instead of nullptr
+			if (pdb.empty()) {
+				printk("Failed to download pdb\r\n");
+				break;
+			}
+			
+			const auto& cpath = pdb.data();
 			if (cpath == 0) break;
 			wcscpy(_pdbPath, cpath);
 			strcpy(_pdbGuid, info.first.data());
@@ -43,7 +50,7 @@ namespace oxygenPdb {
 				break;
 			}
 
-			//symbol map ¾ÍÊÇÁ÷->·ûºÅµÄÓ³Éä
+			//symbol map Â¾ÃÃŠÃ‡ÃÃ·->Â·Ã»ÂºÃ…ÂµÃ„Ã“Â³Ã‰Ã¤
 			symbolic_access::SymbolsExtractor symbolsExtractor(msfReader);
 			_symbols = symbolsExtractor.Extract();
 			if (_symbols.empty())

--- a/oxygen pdb/src/viewer.cpp
+++ b/oxygen pdb/src/viewer.cpp
@@ -79,7 +79,7 @@ namespace oxygenPdb{
 		auto pdbSize=ksocket::getContentLength(url.c_str(), "88");
 		if (pdbSize == 0) {
 			printk("failed to get content length!\r\n");
-			return nullptr;
+			return L"";
 		}
 
 		auto pdbBuf = kstd::make_unique<unsigned char[]>(pdbSize + 500);
@@ -87,14 +87,14 @@ namespace oxygenPdb{
 		if (!bSuc) {
 
 			printk("failed to get pdb file!\r\n");
-			return nullptr;
+			return L"";
 		}
 		ksocket::destory();
 
 		//then we write to disk
 		if (wRetPdbName != wPdbName) {
 			printk("failed to convert ansi to uni!\r\n");
-			return nullptr;
+			return L"";
 		}
 		helper::writeToDisk(L"C:\\Windows\\Temp\\", wRetPdbName,(char*)pdbBuf.get(), pdbSize);
 		


### PR DESCRIPTION
Since std::wstring or std::string does not allow nullptr, it can cause crash(BSOD).
It could be reproduced by disconnecting ethernet.

So I changed downloadPdb()'s nullptr to L"" (Empty string, not null pointer).
Hope it helps.

![image](https://github.com/user-attachments/assets/d2032a2a-3cba-4bc4-a4a9-022b60be94dd)
